### PR TITLE
fix: make latest main compatible with storage extension

### DIFF
--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -149,6 +149,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          apt update && apt install -y git
           pip install .
 
       - name: Upgrade

--- a/src/envoy/admin/manager/config.py
+++ b/src/envoy/admin/manager/config.py
@@ -123,6 +123,9 @@ class ConfigManager:
             )
             site.default_site_control.ramp_rate_percent_per_second = ramp_rate_value
 
+        if request.storage_target_watts is not None:
+            site.default_site_control.storage_target_active_watts = request.storage_target_watts.value
+
         await session.commit()
 
         await NotificationManager.notify_changed_deleted_entities(SubscriptionResource.DEFAULT_SITE_CONTROL, now)

--- a/src/envoy/server/alembic/versions/5a6908457f70_merge_point_1_storage_extension.py
+++ b/src/envoy/server/alembic/versions/5a6908457f70_merge_point_1_storage_extension.py
@@ -1,0 +1,25 @@
+"""merge point 1 storage extension
+
+Revision ID: 5a6908457f70
+Revises: 5a615c22e7ad, fe565b4c1a9e
+Create Date: 2025-06-23 11:28:08.653150
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "5a6908457f70"
+down_revision = ("5a615c22e7ad", "fe565b4c1a9e")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/tests/integration/admin/test_notification.py
+++ b/tests/integration/admin/test_notification.py
@@ -711,6 +711,7 @@ async def test_update_site_default_config_notification(
         generation_limit_watts=None,
         load_limit_watts=None,
         ramp_rate_percent_per_second=None,
+        storage_target_watts=None,
     )
 
     # Update default controls for site 1 and site 2

--- a/tests/unit/admin/manager/test_config.py
+++ b/tests/unit/admin/manager/test_config.py
@@ -21,6 +21,7 @@ from envoy.server.model.site import DefaultSiteControl
                 load_limit_watts=UpdateDefaultValue(value=None),
                 generation_limit_watts=UpdateDefaultValue(value=None),
                 ramp_rate_percent_per_second=UpdateDefaultValue(value=None),
+                storage_target_watts=UpdateDefaultValue(value=None),
             ),
         ),
         (
@@ -31,6 +32,7 @@ from envoy.server.model.site import DefaultSiteControl
                 load_limit_watts=UpdateDefaultValue(value=Decimal(13)),
                 generation_limit_watts=UpdateDefaultValue(value=Decimal(14)),
                 ramp_rate_percent_per_second=UpdateDefaultValue(value=Decimal(15)),
+                storage_target_watts=UpdateDefaultValue(value=Decimal(16)),
             ),
         ),
     ],
@@ -56,5 +58,6 @@ async def test_update_site_control_default_all_vals_update(
         assert saved_result.generation_limit_active_watts == control_request.generation_limit_watts.value
         assert saved_result.load_limit_active_watts == control_request.load_limit_watts.value
         assert saved_result.ramp_rate_percent_per_second == control_request.ramp_rate_percent_per_second.value
+        assert saved_result.storage_target_active_watts == control_request.storage_target_watts.value
 
     mock_notify_changed_deleted_entities.assert_called_once()


### PR DESCRIPTION
Pointed latest migration at merge point. Made necessary changes surrounding default control and config manager for storage extension compatibility. Closes #24 