### PR TITLE
Added aggregator certificate assignment deletion endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "taskiq!=0.11.5,!=0.11.6",      # Known compatibiity issue with pydantic
     "taskiq-aio-pika",
     "parse",
-    "envoy_schema @ git+https://github.com/synergy-au/envoy-schema.git@v0.17.1-rc1-synergy.0.2.0"
+    "envoy_schema @ git+https://github.com/synergy-au/envoy-schema.git@11-add-aggregator-certificate-assignment-deletion-particulars"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "taskiq!=0.11.5,!=0.11.6",      # Known compatibiity issue with pydantic
     "taskiq-aio-pika",
     "parse",
-    "envoy_schema @ git+https://github.com/synergy-au/envoy-schema.git@11-add-aggregator-certificate-assignment-deletion-particulars"
+    "envoy_schema @ git+https://github.com/synergy-au/envoy-schema.git@v0.17.3-rc1-synergy.0.2.0"
 ]
 
 [project.optional-dependencies]

--- a/src/envoy/admin/api/aggregator.py
+++ b/src/envoy/admin/api/aggregator.py
@@ -104,8 +104,6 @@ async def delete_aggregator_certificate_assignment(aggregator_id: int, certifica
         certificate_id: ID of certificate
     """
     try:
-        await manager.CertificateManager.unassign_certificate_for_aggregator(
-            db.session, aggregator_id, certificate_id
-        )
+        await manager.CertificateManager.unassign_certificate_for_aggregator(db.session, aggregator_id, certificate_id)
     except exception.NotFoundError as err:
         raise error_handler.LoggedHttpException(logger, err, http.HTTPStatus.NOT_FOUND, f"{err}")

--- a/src/envoy/admin/crud/aggregator.py
+++ b/src/envoy/admin/crud/aggregator.py
@@ -1,15 +1,15 @@
-from typing import Sequence
+from typing import Sequence, Iterable
 
-from sqlalchemy import func, select
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from envoy.server.model.aggregator import NULL_AGGREGATOR_ID, Aggregator
+from envoy.server.model.aggregator import NULL_AGGREGATOR_ID, Aggregator, AggregatorCertificateAssignment
 
 
 async def count_all_aggregators(session: AsyncSession) -> int:
     """Admin counting of aggregators - the NULL_AGGREGATOR (if present) will not be included"""
-    stmt = select(func.count()).select_from(Aggregator).where(Aggregator.aggregator_id != NULL_AGGREGATOR_ID)
+    stmt = sa.select(sa.func.count()).select_from(Aggregator).where(Aggregator.aggregator_id != NULL_AGGREGATOR_ID)
     resp = await session.execute(stmt)
     return resp.scalar_one()
 
@@ -18,7 +18,7 @@ async def select_all_aggregators(session: AsyncSession, start: int, limit: int) 
     """Admin selecting of aggregators - will include domains relationship (the NULL_AGGREGATOR is not included)"""
 
     stmt = (
-        select(Aggregator)
+        sa.select(Aggregator)
         .offset(start)
         .limit(limit)
         .where(Aggregator.aggregator_id != NULL_AGGREGATOR_ID)
@@ -32,3 +32,21 @@ async def select_all_aggregators(session: AsyncSession, start: int, limit: int) 
 
     resp = await session.execute(stmt)
     return resp.scalars().all()
+
+
+async def unassign_many_certificates(session: AsyncSession, aggregator_id: int, certificate_ids: Iterable[int]) -> None:
+    """Unassign certificates from an aggregator.
+
+    Does nothing if the relationship doesn't exist.
+
+    Args:
+        session: Database session
+        aggregator_id: ID of aggregator to have certificates unasssigned
+        certificate_ids: IDs of all certificates to unassign
+    """
+    stmt = (
+        sa.delete(AggregatorCertificateAssignment)
+        .where(AggregatorCertificateAssignment.aggregator_id == aggregator_id)
+        .where(AggregatorCertificateAssignment.certificate_id.in_(certificate_ids))
+    )
+    await session.execute(stmt)

--- a/src/envoy/admin/crud/certificate.py
+++ b/src/envoy/admin/crud/certificate.py
@@ -44,3 +44,11 @@ async def select_all_certificates_for_aggregator(
     resp = await session.execute(stmt)
 
     return resp.scalars().all()
+
+
+async def select_certificate(session: AsyncSession, certificate_id: int) -> base.Certificate | None:
+    """Select a single certificate by ID"""
+    stmt = select(base.Certificate).where(base.Certificate.certificate_id == certificate_id)
+
+    resp = await session.execute(stmt)
+    return resp.scalar_one_or_none()

--- a/src/envoy/admin/manager/certificate.py
+++ b/src/envoy/admin/manager/certificate.py
@@ -3,6 +3,7 @@ from envoy_schema.admin.schema.certificate import CertificatePageResponse
 
 from envoy.admin import crud
 from envoy.server import crud as server_crud
+from envoy.server import exception
 from envoy.admin import mapper
 
 
@@ -20,3 +21,28 @@ class CertificateManager:
         return mapper.CertificateMapper.map_to_page_response(
             total_count=cert_count, start=start, limit=limit, certificates=cert_list
         )
+
+    @staticmethod
+    async def unassign_certificate_for_aggregator(
+            session: AsyncSession, aggregator_id: int, certificate_id: int
+    ) -> None:
+        """Delete aggregator certificate assignment.
+
+        Certificates are left untouched, only the join entry is deleted
+
+        Args:
+            aggregator_id: Aggregator that the certificates belong to
+            certificate_ids: List of certificates to be unassigned. Does nothing if the relationship
+                doesn't exist
+
+        Raises:
+            NotFoundError: if aggregator id or certificate id is invalid
+        """
+        if not await server_crud.aggregator.select_aggregator(session, aggregator_id):
+            raise exception.NotFoundError(f"Aggregator with id {aggregator_id} not found")
+
+        if not await crud.certificate.select_certificate(session, certificate_id):
+            raise exception.NotFoundError(f"Certificate with id {certificate_id} not found")
+
+        await crud.aggregator.unassign_many_certificates(session, aggregator_id, [certificate_id])
+        await session.commit()

--- a/src/envoy/admin/manager/certificate.py
+++ b/src/envoy/admin/manager/certificate.py
@@ -24,7 +24,7 @@ class CertificateManager:
 
     @staticmethod
     async def unassign_certificate_for_aggregator(
-            session: AsyncSession, aggregator_id: int, certificate_id: int
+        session: AsyncSession, aggregator_id: int, certificate_id: int
     ) -> None:
         """Delete aggregator certificate assignment.
 

--- a/tests/integration/admin/test_aggregator.py
+++ b/tests/integration/admin/test_aggregator.py
@@ -152,3 +152,39 @@ async def test_get_aggregator_certificates(
         assert cert_page.start == start
 
     assert [a.certificate_id for a in cert_page.certificates] == expected_cert_ids
+
+
+@pytest.mark.parametrize(
+    "agg_id,cert_id,expected_ids",
+    [
+        (1, 1, [2, 3]),
+        (1, 2, [1, 3]),
+        (1, 3, [1, 2]),
+        (1, 111, None),
+        (111, 1, None),
+    ],
+)
+@pytest.mark.anyio
+async def test_delete_aggregator_certificate_assignments(
+    admin_client_auth: AsyncClient,
+    agg_id: int,
+    cert_id: int,
+    expected_ids: list[int],
+) -> None:
+    del_res = await admin_client_auth.delete(
+        uri.AggregatorCertificateUri.format(aggregator_id=agg_id, certificate_id=cert_id)
+    )
+
+    if expected_ids is None:
+        assert del_res.status_code == HTTPStatus.NOT_FOUND
+        return
+
+    assert del_res.status_code == HTTPStatus.NO_CONTENT
+
+    get_res = await admin_client_auth.get(uri.AggregatorCertificateListUri.format(aggregator_id=agg_id))
+
+    body = response.read_response_body_string(get_res)
+    cert_page = CertificatePageResponse.model_validate_json(body)
+    certs = cert_page.certificates
+
+    assert [c.certificate_id for c in certs] == expected_ids

--- a/tests/unit/admin/crud/test_aggregator.py
+++ b/tests/unit/admin/crud/test_aggregator.py
@@ -1,21 +1,22 @@
+import psycopg
 import pytest
 from assertical.fixtures.postgres import generate_async_session
 from sqlalchemy import select
 
-from envoy.admin.crud.aggregator import count_all_aggregators, select_all_aggregators
+from envoy.admin import crud
 from envoy.server.model.aggregator import Aggregator, AggregatorDomain
 
 
 @pytest.mark.anyio
-async def test_count_all_aggregators(pg_base_config):
+async def test_count_all_aggregators(pg_base_config: psycopg.Connection) -> None:
     async with generate_async_session(pg_base_config) as session:
-        assert (await count_all_aggregators(session)) == 3
+        assert (await crud.aggregator.count_all_aggregators(session)) == 3
 
 
 @pytest.mark.anyio
-async def test_count_all_aggregators_empty(pg_empty_config):
+async def test_count_all_aggregators_empty(pg_empty_config: psycopg.Connection) -> None:
     async with generate_async_session(pg_empty_config) as session:
-        assert (await count_all_aggregators(session)) == 0
+        assert (await crud.aggregator.count_all_aggregators(session)) == 0
 
 
 @pytest.mark.parametrize(
@@ -30,10 +31,14 @@ async def test_count_all_aggregators_empty(pg_empty_config):
 )
 @pytest.mark.anyio
 async def test_select_aggregators(
-    pg_base_config, start: int, limit: int, expected_aggregator_ids: list[int], expected_domain_ids: list[int]
-):
+    pg_base_config: psycopg.Connection,
+    start: int,
+    limit: int,
+    expected_aggregator_ids: list[int],
+    expected_domain_ids: list[int],
+) -> None:
     async with generate_async_session(pg_base_config) as session:
-        aggs = await select_all_aggregators(session, start, limit)
+        aggs = await crud.aggregator.select_all_aggregators(session, start, limit)
         assert len(aggs) == len(expected_aggregator_ids)
         assert all([isinstance(s, Aggregator) for s in aggs])
         assert expected_aggregator_ids == [a.aggregator_id for a in aggs]
@@ -42,7 +47,7 @@ async def test_select_aggregators(
 
 @pytest.mark.parametrize("agg_id_to_delete", [1, 2, 3])
 @pytest.mark.anyio
-async def test_select_aggregators_no_domains(pg_base_config, agg_id_to_delete: int):
+async def test_select_aggregators_no_domains(pg_base_config: psycopg.Connection, agg_id_to_delete: int) -> None:
 
     async with generate_async_session(pg_base_config) as session:
         stmt = select(AggregatorDomain).where(AggregatorDomain.aggregator_id == agg_id_to_delete)
@@ -53,6 +58,56 @@ async def test_select_aggregators_no_domains(pg_base_config, agg_id_to_delete: i
         await session.commit()
 
     async with generate_async_session(pg_base_config) as session:
-        aggs = await select_all_aggregators(session, 0, 99)
+        aggs = await crud.aggregator.select_all_aggregators(session, 0, 99)
         agg_no_domains = [a for a in aggs if a.aggregator_id == agg_id_to_delete][0]
         assert len(agg_no_domains.domains) == 0
+
+
+@pytest.mark.parametrize(
+    "agg_id,certificate_ids,expected_ids",
+    [
+        (1, [1], [2, 3]),
+        (1, [2], [1, 3]),
+        (1, [3], [1, 2]),
+        (1, [1, 2], [3]),
+        (1, [1, 2, 3], []),
+        (2, [4], []),
+        (1, [4], [1, 2, 3]),
+    ],
+)
+@pytest.mark.anyio
+async def test_unassign_many_certificates(
+    pg_base_config: psycopg.Connection, agg_id: int, certificate_ids: list[int], expected_ids: list[int]
+) -> None:
+    async with generate_async_session(pg_base_config) as session:
+        await crud.aggregator.unassign_many_certificates(session, agg_id, certificate_ids)
+        actual = await crud.certificate.select_all_certificates_for_aggregator(session, agg_id, 0, 500)
+        assert [a.certificate_id for a in actual] == expected_ids
+
+
+@pytest.mark.parametrize(
+    "agg_id,cert_ids,one_certs,two_certs,three_certs",
+    [
+        (1, [4], [1, 2, 3], [4], [5]),
+        (1, [6], [1, 2, 3], [4], [5]),
+        (2, [4], [1, 2, 3], [], [5]),
+    ]
+)
+@pytest.mark.anyio
+async def test_unassign_many_certificates_no_cross_contamination(
+    pg_base_config: psycopg.Connection,
+    agg_id: int,
+    cert_ids: list[int],
+    one_certs: list[int],
+    two_certs: list[int],
+    three_certs: list[int],
+) -> None:
+    """Testing to ensure the unassignment of a certificate from one aggregator doesn't affect another"""
+    async with generate_async_session(pg_base_config) as session:
+        await crud.aggregator.unassign_many_certificates(session, agg_id, cert_ids)
+        actual_ones = await crud.certificate.select_all_certificates_for_aggregator(session, 1, 0, 500)
+        actual_twos = await crud.certificate.select_all_certificates_for_aggregator(session, 2, 0, 500)
+        actual_threes = await crud.certificate.select_all_certificates_for_aggregator(session, 3, 0, 500)
+        assert [a.certificate_id for a in actual_ones] == one_certs
+        assert [a.certificate_id for a in actual_twos] == two_certs
+        assert [a.certificate_id for a in actual_threes] == three_certs

--- a/tests/unit/admin/crud/test_aggregator.py
+++ b/tests/unit/admin/crud/test_aggregator.py
@@ -91,7 +91,7 @@ async def test_unassign_many_certificates(
         (1, [4], [1, 2, 3], [4], [5]),
         (1, [6], [1, 2, 3], [4], [5]),
         (2, [4], [1, 2, 3], [], [5]),
-    ]
+    ],
 )
 @pytest.mark.anyio
 async def test_unassign_many_certificates_no_cross_contamination(

--- a/tests/unit/admin/crud/test_certificate.py
+++ b/tests/unit/admin/crud/test_certificate.py
@@ -39,12 +39,12 @@ async def test_select_certificate(pg_base_config: psycopg.Connection) -> None:
         cert_1 = await crud.certificate.select_certificate(session, 1)
         assert isinstance(cert_1, base.Certificate)
         assert cert_1.lfdi == "854d10a201ca99e5e90d3c3e1f9bc1c3bd075f3b"
-        assert cert_1.expiry == dt.datetime.fromisoformat("2037-01-01T01:02:03+00")
+        assert cert_1.expiry == dt.datetime.fromisoformat("2037-01-01T01:02:03+00:00")
 
         cert_2 = await crud.certificate.select_certificate(session, 2)
         assert isinstance(cert_2, base.Certificate)
         assert cert_2.lfdi == "403ba02aa36fa072c47eb3299daaafe94399adad"
-        assert cert_2.expiry == dt.datetime.fromisoformat("2037-01-01T02:03:04+00")
+        assert cert_2.expiry == dt.datetime.fromisoformat("2037-01-01T02:03:04+00:00")
 
         assert (await crud.certificate.select_certificate(session, 6)) is None
         assert (await crud.certificate.select_certificate(session, -1)) is None

--- a/tests/unit/admin/crud/test_certificate.py
+++ b/tests/unit/admin/crud/test_certificate.py
@@ -39,12 +39,12 @@ async def test_select_certificate(pg_base_config: psycopg.Connection) -> None:
         cert_1 = await crud.certificate.select_certificate(session, 1)
         assert isinstance(cert_1, base.Certificate)
         assert cert_1.lfdi == "854d10a201ca99e5e90d3c3e1f9bc1c3bd075f3b"
-        assert cert_1.expiry == dt.datetime.fromisoformat("2037-01-01 01:02:03+00")
+        assert cert_1.expiry == dt.datetime.fromisoformat("2037-01-01T01:02:03+00")
 
         cert_2 = await crud.certificate.select_certificate(session, 2)
         assert isinstance(cert_2, base.Certificate)
         assert cert_2.lfdi == "403ba02aa36fa072c47eb3299daaafe94399adad"
-        assert cert_2.expiry == dt.datetime.fromisoformat("2037-01-01 02:03:04+00")
+        assert cert_2.expiry == dt.datetime.fromisoformat("2037-01-01T02:03:04+00")
 
         assert (await crud.certificate.select_certificate(session, 6)) is None
         assert (await crud.certificate.select_certificate(session, -1)) is None

--- a/tests/unit/admin/manager/test_certificate.py
+++ b/tests/unit/admin/manager/test_certificate.py
@@ -1,0 +1,47 @@
+import psycopg
+import pytest
+from assertical.fixtures import postgres
+
+from envoy.admin import manager
+from envoy.admin import crud
+from envoy.server import exception
+
+
+@pytest.mark.parametrize(
+    "agg_id,cert_id,expected_ids",
+    [
+        (1, 1, [2, 3]),
+        (1, 2, [1, 3]),
+        (1, 3, [1, 2]),
+    ],
+)
+@pytest.mark.anyio
+async def test_unassign_certificate_for_aggregator(
+    pg_base_config: psycopg.Connection, agg_id: int, cert_id: int, expected_ids: list[int]
+) -> None:
+    """Happy path tests for unassign_certificate_for_aggregator() method"""
+    async with postgres.generate_async_session(pg_base_config) as session:
+        # invoke method
+        await manager.certificate.CertificateManager.unassign_certificate_for_aggregator(session, agg_id, cert_id)
+
+        # query certificates
+        actual_certs = await crud.certificate.select_all_certificates_for_aggregator(session, agg_id, 0, 500)
+
+        # assert
+        assert [a.certificate_id for a in actual_certs] == expected_ids
+
+
+@pytest.mark.anyio
+async def test_unassign_certificate_invalid_aggregator_id(pg_base_config: psycopg.Connection) -> None:
+    """Confirm correct error raised"""
+    async with postgres.generate_async_session(pg_base_config) as session:
+        with pytest.raises(exception.NotFoundError, match="Aggregator with id 1111 not found"):
+            await manager.certificate.CertificateManager.unassign_certificate_for_aggregator(session, 1111, 1)
+
+
+@pytest.mark.anyio
+async def test_unassign_certificate_invalid_certificate_id(pg_base_config: psycopg.Connection) -> None:
+    """Confirm correct error raised"""
+    async with postgres.generate_async_session(pg_base_config) as session:
+        with pytest.raises(exception.NotFoundError, match="Certificate with id 1111 not found"):
+            await manager.certificate.CertificateManager.unassign_certificate_for_aggregator(session, 1, 1111)


### PR DESCRIPTION
Enables deletion of the assignment. Certificates are left untouched, it only removes the join table entry.  Depends on https://github.com/synergy-au/envoy-schema/pull/19. Closes #17.